### PR TITLE
make GetRequestBeanInstance public to allow writing custom middleware

### DIFF
--- a/di.go
+++ b/di.go
@@ -512,7 +512,8 @@ func GetInstanceSafe(beanID string) (interface{}, error) {
 	return getInstance(context.Background(), beanID, make(map[string]bool))
 }
 
-func getRequestBeanInstance(ctx context.Context, beanID string) interface{} {
+//GetInstanceSafe function returns bean instance by its ID with scope of the context. It may panic.
+func GetRequestBeanInstance(ctx context.Context, beanID string) interface{} {
 	if atomic.CompareAndSwapInt32(&containerInitialized, 0, 0) {
 		panic("container is not initialized: can't lookup instances of beans yet")
 	}

--- a/di.go
+++ b/di.go
@@ -512,7 +512,7 @@ func GetInstanceSafe(beanID string) (interface{}, error) {
 	return getInstance(context.Background(), beanID, make(map[string]bool))
 }
 
-//GetInstanceSafe function returns bean instance by its ID with scope of the context. It may panic.
+// GetRequestBeanInstance function returns bean instance by its ID with scope of the context. It may panic.
 func GetRequestBeanInstance(ctx context.Context, beanID string) interface{} {
 	if atomic.CompareAndSwapInt32(&containerInitialized, 0, 0) {
 		panic("container is not initialized: can't lookup instances of beans yet")

--- a/di_test.go
+++ b/di_test.go
@@ -1006,7 +1006,7 @@ func (suite *TestSuite) TestFailRequestBeanRetrieval() {
 	err = InitializeContainer()
 	assert.NoError(suite.T(), err)
 	assert.Panics(suite.T(), func() {
-		getRequestBeanInstance(context.Background(), "requestBean")
+		GetRequestBeanInstance(context.Background(), "requestBean")
 	})
 }
 

--- a/di_test.go
+++ b/di_test.go
@@ -1152,7 +1152,7 @@ func (suite *TestSuite) TestShutdownErrorOnClose() {
 }
 
 func (suite *TestSuite) TestShutdownContinueOnError() {
-	//cause of map usage internally in RegisterBean and order is unknown
+	// cause of map usage internally in RegisterBean and order is unknown
 	for i := 1; i < 10; i++ {
 		_, _ = RegisterBean("a"+strconv.Itoa(i), reflect.TypeOf((*SingletonBeanWithClose)(nil)))
 		i++

--- a/middleware.go
+++ b/middleware.go
@@ -33,7 +33,7 @@ func Middleware(next http.Handler) http.Handler {
 			if scope != Request {
 				continue
 			}
-			beanInstance := getRequestBeanInstance(requestContext, beanID)
+			beanInstance := GetRequestBeanInstance(requestContext, beanID)
 			requestContext = context.WithValue(requestContext, BeanKey(beanID), beanInstance)
 			if isCloseable(beanInstance) {
 				go func(ctx context.Context, beanInstance interface{}) {


### PR DESCRIPTION
GetRequestBeanInstance was private which had prevent to make custom implementation for middleware in Go frameworks.